### PR TITLE
Fix: logo size 350px

### DIFF
--- a/assets/style.scss
+++ b/assets/style.scss
@@ -227,7 +227,7 @@ p > img {
 
 .site-avatar {
   float: left;
-  width: 220px;
+  width: 350px;
   height: auto;
   margin-right: 15px;
 
@@ -235,7 +235,7 @@ p > img {
     float: none;
     display: block;
     margin: 0 auto;
-    width: 180px;
+    width: 280px;
   }
 
   img {


### PR DESCRIPTION
## Summary
- Increase `.site-avatar` width from 220px → 350px (desktop) and 180px → 280px (mobile)
- Restores the logo size from the earlier session

🤖 Generated with [Claude Code](https://claude.com/claude-code)