### PR TITLE
Strip placeholder content, show only live content

### DIFF
--- a/_pages/guides.html
+++ b/_pages/guides.html
@@ -65,29 +65,3 @@ permalink: /guides/
     </a>
   </div>
 </div>
-
-<div class="section">
-  <div class="section-header">
-    <h2>Coming Soon</h2>
-  </div>
-  <div class="guide-list">
-    <div class="guide-item guide-item-dimmed">
-      <div class="guide-item-left">
-        <div class="guide-icon">2.1</div>
-        <div>
-          <h4>OAuth 2.1 Integration Patterns</h4>
-          <div class="guide-desc">Modern authorization flows for web, mobile, and machine clients</div>
-        </div>
-      </div>
-    </div>
-    <div class="guide-item guide-item-dimmed">
-      <div class="guide-item-left">
-        <div class="guide-icon">MCP</div>
-        <div>
-          <h4>MCP Gateway Configuration</h4>
-          <div class="guide-desc">Setting up an identity-aware gateway for Model Context Protocol</div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>

--- a/_pages/ideas.html
+++ b/_pages/ideas.html
@@ -9,38 +9,7 @@ permalink: /ideas/
 </div>
 
 <div class="section">
-  <div class="post-grid">
-    <div class="post-card post-card-featured">
-      <div class="post-card-meta">
-        <span class="post-card-tag">Agentic AI &amp; NHI</span>
-        <span class="post-card-date">Coming soon</span>
-      </div>
-      <h3>When the User Is an Agent: The Identity Problem Nobody's Ready For</h3>
-      <p>We've spent two decades building identity infrastructure for humans. But the user isn't a person anymore. The identity infrastructure underneath it? Nonexistent.</p>
-    </div>
-    <div class="post-card">
-      <div class="post-card-meta">
-        <span class="post-card-tag">Identity Governance</span>
-        <span class="post-card-date">Coming soon</span>
-      </div>
-      <h3>Dynamic Groups vs. Policy Orchestration: The IGA Debate Nobody's Having</h3>
-      <p>Most vendors treat dynamic groups as the answer to governance automation. They're wrong.</p>
-    </div>
-    <div class="post-card">
-      <div class="post-card-meta">
-        <span class="post-card-tag">Identity Security</span>
-        <span class="post-card-date">Coming soon</span>
-      </div>
-      <h3>Why Your IdP Needs a Kill Switch</h3>
-      <p>When an agent goes sideways, you need one control to revoke all its access immediately.</p>
-    </div>
-    <div class="post-card">
-      <div class="post-card-meta">
-        <span class="post-card-tag">Competitive Landscape</span>
-        <span class="post-card-date">Coming soon</span>
-      </div>
-      <h3>The Microsoft Problem: Why Entra ID Isn't Enough</h3>
-      <p>Deep hooks into the Microsoft ecosystem don't mean much when your customers run multi-cloud.</p>
-    </div>
+  <div class="coming-soon-message">
+    <p>Coming soon. Stay tuned for opinions and analysis on identity infrastructure, agentic AI, and the future of access management.</p>
   </div>
 </div>

--- a/_pages/industry.html
+++ b/_pages/industry.html
@@ -9,36 +9,7 @@ permalink: /industry/
 </div>
 
 <div class="section">
-  <div class="industry-entry">
-    <div class="industry-date">Mar 2026</div>
-    <div class="industry-content">
-      <div class="industry-company">CyberArk</div>
-      <h4>CyberArk announces agentic identity capabilities in Identity Security Platform</h4>
-      <p>PAM-first approach to agent lifecycle management. Interesting but narrow &mdash; locking down privileged access isn't the same as orchestrating dynamic delegation. Watch for how they handle non-privileged agent flows.</p>
-    </div>
-  </div>
-  <div class="industry-entry">
-    <div class="industry-date">Mar 2026</div>
-    <div class="industry-content">
-      <div class="industry-company">Ping Identity</div>
-      <h4>Ping ships MCP Gateway preview in PingOne platform</h4>
-      <p>Gateway interceptor model for MCP traffic. Smart strategy &mdash; inspect and authorize at the gateway layer. Question is whether they can execute at the speed the agentic ecosystem is moving.</p>
-    </div>
-  </div>
-  <div class="industry-entry">
-    <div class="industry-date">Feb 2026</div>
-    <div class="industry-content">
-      <div class="industry-company">Dscope</div>
-      <h4>Dscope raises $12M Series A for non-human identity management</h4>
-      <p>NHI startup focused on secret sprawl and service account governance. Solid niche, but the real opportunity is in agent identity &mdash; which requires more than credential management.</p>
-    </div>
-  </div>
-  <div class="industry-entry">
-    <div class="industry-date">Feb 2026</div>
-    <div class="industry-content">
-      <div class="industry-company">IETF</div>
-      <h4>OAuth 2.1 draft advances with PKCE requirement and implicit flow removal</h4>
-      <p>Long overdue cleanup. PKCE as mandatory and killing implicit flow are the right calls. Now we need the working groups to tackle agent-specific grant types.</p>
-    </div>
+  <div class="coming-soon-message">
+    <p>Coming soon. This is where I'll track the moves that matter in the identity market.</p>
   </div>
 </div>

--- a/_pages/talks.html
+++ b/_pages/talks.html
@@ -9,25 +9,7 @@ permalink: /talks/
 </div>
 
 <div class="section">
-  <div class="talk-card">
-    <h4>When the User Is an Agent: Rethinking IAM for the Agentic Era</h4>
-    <div class="talk-venue">Cisco Live &mdash; Las Vegas, NV &bull; June 2026</div>
-    <div class="talk-desc">Identity infrastructure was built for humans. AI agents break every assumption: no browsers, no passwords, no interactive flows. This talk explores what agent identity actually requires &mdash; registration, delegation, runtime policy, and kill switches &mdash; and where the industry stands today.</div>
-    <div class="talk-meta">
-      <span class="talk-meta-link">Slides coming soon</span>
-      <span class="talk-meta-link">Video coming soon</span>
-    </div>
-  </div>
-  <div class="talk-card">
-    <h4>The Identity Security Imperative: From MFA to Zero Trust</h4>
-    <div class="talk-venue">Gartner IAM Summit &mdash; 2025</div>
-    <div class="talk-desc">How Cisco Duo is evolving from MFA provider to full identity security platform. Covers SSO, passwordless, identity governance, and the convergence of authentication and authorization.</div>
-    <div class="talk-meta">
-      <span class="talk-meta-link">Slides coming soon</span>
-    </div>
-  </div>
-  <div class="talk-card talk-card-dimmed">
-    <h4>More talks coming...</h4>
-    <div class="talk-desc">Past analyst briefings and conference appearances will be added here.</div>
+  <div class="coming-soon-message">
+    <p>Coming soon. Check back for slides, videos, and writeups from conference appearances and analyst briefings.</p>
   </div>
 </div>

--- a/assets/style.scss
+++ b/assets/style.scss
@@ -666,6 +666,15 @@ pre {
   margin: 0;
 }
 
+a.post-card-link {
+  display: block;
+  color: inherit;
+
+  &:hover {
+    opacity: 1;
+  }
+}
+
 .post-card-featured {
   border-color: rgba(45, 216, 130, 0.3);
   background: linear-gradient(135deg, $surface 0%, rgba(45, 216, 130, 0.05) 100%);
@@ -711,10 +720,6 @@ pre {
     align-items: flex-start;
     gap: 8px;
   }
-}
-
-.guide-item-dimmed {
-  opacity: 0.5;
 }
 
 .guide-item-left {
@@ -821,10 +826,6 @@ pre {
   }
 }
 
-.talk-card-dimmed {
-  opacity: 0.5;
-}
-
 .talk-venue {
   font-size: 14px;
   color: $accent;
@@ -850,6 +851,22 @@ pre {
   border: 1px solid $border;
   border-radius: 6px;
   color: $textMuted;
+}
+
+// ─── COMING SOON ───
+
+.coming-soon-message {
+  background: $surface;
+  border: 1px solid $border;
+  border-radius: 12px;
+  padding: 40px 32px;
+  text-align: center;
+
+  p {
+    color: $textSecondary;
+    font-size: 16px;
+    margin: 0;
+  }
 }
 
 // Syntax highlighting (dark)

--- a/index.html
+++ b/index.html
@@ -19,46 +19,23 @@ layout: default
   <div class="section-header">
     <h2>Featured</h2>
   </div>
-  <div class="post-card post-card-featured">
+  <a href="{{ site.baseurl }}/Duo-SSO-NinjaOne/" class="post-card post-card-featured post-card-link">
     <div class="post-card-meta">
-      <span class="post-card-tag">Agentic AI &amp; NHI</span>
-      <span class="post-card-date">Coming soon</span>
+      <span class="post-card-tag">SAML Guide</span>
+      <span class="post-card-date">January 22, 2022</span>
     </div>
-    <h3>When the User Is an Agent: The Identity Problem Nobody's Ready For</h3>
-    <p>We've spent two decades building identity infrastructure for humans. SAML federations. OAuth flows. MFA policies. But the user isn't a person anymore &mdash; it's an AI agent booking your meetings, pulling customer data, and refactoring your codebase.</p>
-  </div>
+    <h3>Duo SSO + NinjaOne Configuration Guide</h3>
+    <p>How to Configure Duo SSO SAML 2.0 for NinjaOne. Step-by-step integration guide with prerequisites, configuration steps, and testing.</p>
+  </a>
 </div>
 
-<!-- Latest Ideas -->
+<!-- Latest -->
 <div class="section">
   <div class="section-header">
-    <h2>Latest Ideas</h2>
-    <a href="{{ site.baseurl }}/ideas">View all &rarr;</a>
+    <h2>Latest</h2>
+    <a href="{{ site.baseurl }}/guides">All guides &rarr;</a>
   </div>
-  <div class="post-grid">
-    <div class="post-card">
-      <div class="post-card-meta">
-        <span class="post-card-tag">Identity Governance</span>
-        <span class="post-card-date">Coming soon</span>
-      </div>
-      <h3>Dynamic Groups vs. Policy Orchestration: The IGA Debate Nobody's Having</h3>
-      <p>Most vendors treat dynamic groups as the answer to governance automation. They're wrong. Here's why policy orchestration is the real unlock.</p>
-    </div>
-    <div class="post-card">
-      <div class="post-card-meta">
-        <span class="post-card-tag">Identity Security</span>
-        <span class="post-card-date">Coming soon</span>
-      </div>
-      <h3>Why Your IdP Needs a Kill Switch</h3>
-      <p>When an agent goes sideways, you need one control to revoke all its access immediately. Most identity platforms can't do this. That's terrifying.</p>
-    </div>
-    <div class="post-card">
-      <div class="post-card-meta">
-        <span class="post-card-tag">Competitive Landscape</span>
-        <span class="post-card-date">Coming soon</span>
-      </div>
-      <h3>The Microsoft Problem: Why Entra ID Isn't Enough</h3>
-      <p>Deep hooks into the Microsoft ecosystem don't mean much when your customers run multi-cloud, multi-IdP, and increasingly agentic workloads.</p>
-    </div>
+  <div class="coming-soon-message">
+    <p>More content coming soon. In the meantime, check out the <a href="{{ site.baseurl }}/guides">Guides</a> section for Duo SSO SAML integration walkthroughs.</p>
   </div>
 </div>


### PR DESCRIPTION
## Summary
The previous PR merged before the cleanup commit landed. This fixes it:

- **Homepage**: Featured card now links to real NinjaOne guide (not the placeholder Agentic AI post). "Latest" section shows "more coming soon" message.
- **Ideas/Industry/Talks**: Replaced placeholder cards/entries with clean "coming soon" messages
- **Guides**: Removed "Coming Soon" section (OAuth 2.1, MCP Gateway placeholders)
- CSS: Added `.coming-soon-message`, `.post-card-link`; removed unused `.guide-item-dimmed`, `.talk-card-dimmed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)