### PR TITLE
Add 3 talks to Talks page

### DIFF
--- a/_pages/talks.html
+++ b/_pages/talks.html
@@ -9,7 +9,31 @@ permalink: /talks/
 </div>
 
 <div class="section">
-  <div class="coming-soon-message">
-    <p>Coming soon. Check back for slides, videos, and writeups from conference appearances and analyst briefings.</p>
+  <div class="talk-card">
+    <h4>Cisco Presents: IAM Built for the Imposter Era</h4>
+    <div class="talk-venue">Identiverse 2025 &mdash; Mandalay Bay, Las Vegas &bull; June 4, 2025</div>
+    <div class="talk-desc">How a security-first approach to IAM can address key security concerns while reducing complexity and costs. Explores strategies for balancing frictionless access with effective impostor detection, and flexible identity management suited for today's extended workforce.</div>
+    <div class="talk-meta">
+      <a href="https://identiverse.com/idv25/session/?idvid=2997608">Session details</a>
+      <a href="https://www.dropbox.com/scl/fi/lfaexwmlxuimckh8hpz7w/Cisco-Presents-IAM-Built-for-the-Imposter-Era.pdf?rlkey=si12acwt14xpt79u2ezodtd5z&st=rytqd6xr&dl=0">Slides (PDF)</a>
+    </div>
+  </div>
+
+  <div class="talk-card">
+    <h4>Duo's Big Unveil: Announcing Duo IAM</h4>
+    <div class="talk-venue">Duo Security Livestream &bull; May 29, 2025</div>
+    <div class="talk-desc">Joined Matt Caulfield, VP of Identity at Duo, to announce Duo IAM &mdash; Cisco's entry into the IAM and Identity Security market. Live unveil of what attackers will hate and users will love.</div>
+    <div class="talk-meta">
+      <a href="https://www.youtube.com/watch?v=BSVl239nJnc">Watch on YouTube</a>
+    </div>
+  </div>
+
+  <div class="talk-card">
+    <h4>Innovation in Authentication and More</h4>
+    <div class="talk-venue">Authenticate 2024 Keynote &mdash; FIDO Alliance &bull; Published Feb 6, 2025</div>
+    <div class="talk-desc">Keynote presentation with Matthew Miller exploring innovation in authentication &mdash; passkeys, FIDO standards, and what's next for passwordless.</div>
+    <div class="talk-meta">
+      <a href="https://www.youtube.com/watch?v=nwJWE9qxmKw">Watch on YouTube</a>
+    </div>
   </div>
 </div>

--- a/_pages/talks.html
+++ b/_pages/talks.html
@@ -22,7 +22,7 @@ permalink: /talks/
   <div class="talk-card">
     <h4>Duo's Big Unveil: Announcing Duo IAM</h4>
     <div class="talk-venue">Duo Security Livestream &bull; May 29, 2025</div>
-    <div class="talk-desc">Joined Matt Caulfield, VP of Identity at Duo, to announce Duo IAM &mdash; Cisco's entry into the IAM and Identity Security market. Live unveil of what attackers will hate and users will love.</div>
+    <div class="talk-desc">Joined <a href="https://www.linkedin.com/in/mcaulfie/">Matt Caulfield</a>, VP of Identity at Duo, to announce Duo IAM &mdash; Cisco's entry into the IAM and Identity Security market. Live unveil of what attackers will hate and users will love.</div>
     <div class="talk-meta">
       <a href="https://www.youtube.com/watch?v=BSVl239nJnc">Watch on YouTube</a>
     </div>
@@ -31,7 +31,7 @@ permalink: /talks/
   <div class="talk-card">
     <h4>Innovation in Authentication and More</h4>
     <div class="talk-venue">Authenticate 2024 Keynote &mdash; FIDO Alliance &bull; Published Feb 6, 2025</div>
-    <div class="talk-desc">Keynote presentation with Matthew Miller exploring innovation in authentication &mdash; passkeys, FIDO standards, and what's next for passwordless.</div>
+    <div class="talk-desc">Keynote presentation with <a href="https://www.linkedin.com/in/iammatthewmiller/">Matthew Miller</a> exploring innovation in authentication &mdash; passkeys, FIDO standards, and what's next for passwordless.</div>
     <div class="talk-meta">
       <a href="https://www.youtube.com/watch?v=nwJWE9qxmKw">Watch on YouTube</a>
     </div>

--- a/assets/style.scss
+++ b/assets/style.scss
@@ -844,13 +844,20 @@ a.post-card-link {
   gap: 16px;
 }
 
-.talk-meta-link {
+.talk-meta a {
   font-size: 13px;
   font-weight: 500;
   padding: 4px 12px;
   border: 1px solid $border;
   border-radius: 6px;
-  color: $textMuted;
+  color: $textSecondary;
+  transition: all 0.2s;
+
+  &:hover {
+    border-color: $accent;
+    color: $accent;
+    opacity: 1;
+  }
 }
 
 // ─── COMING SOON ───


### PR DESCRIPTION
## Summary
Replaces the "coming soon" placeholder on the Talks page with 3 real talks, ordered newest first:

1. **Cisco Presents: IAM Built for the Imposter Era** — Identiverse 2025, June 4, 2025
   - Links: [Session details](https://identiverse.com/idv25/session/?idvid=2997608) + [Slides PDF](https://www.dropbox.com/scl/fi/lfaexwmlxuimckh8hpz7w/Cisco-Presents-IAM-Built-for-the-Imposter-Era.pdf?rlkey=si12acwt14xpt79u2ezodtd5z&st=rytqd6xr&dl=0)

2. **Duo's Big Unveil: Announcing Duo IAM** — Duo Security Livestream, May 29, 2025
   - With Matt Caulfield, VP of Identity
   - Link: [YouTube](https://www.youtube.com/watch?v=BSVl239nJnc)

3. **Innovation in Authentication and More** — Authenticate 2024 Keynote, FIDO Alliance
   - With Matthew Miller
   - Link: [YouTube](https://www.youtube.com/watch?v=nwJWE9qxmKw)

Also updated `.talk-meta` CSS from static `<span>` styling to `<a>` link styling with hover states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)