### PR TITLE
Style About page focus areas with indented cards

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -14,13 +14,12 @@ The identity landscape is shifting. The "user" is no longer just a human; it's a
 
 What I focus on:
 
-🔐 Access Management & Authentication - SSO, passwordless, MFA, federation, passkeys, policy orchestration
-
-⚙️ Identity Governance (IGA) - Access reviews, provisioning/deprovisioning, lifecycle management
-
-🤖 Agentic AI & Non-Human Identity - Agent lifecycle, MCP, token exchange, authorization policy
-
-🛡️ Identity Security - Identity proofing, credential management, threat detection
+<div class="focus-areas">
+  <div class="focus-item">🔐 <strong>Access Management & Authentication</strong> — SSO, passwordless, MFA, federation, passkeys, policy orchestration</div>
+  <div class="focus-item">⚙️ <strong>Identity Governance (IGA)</strong> — Access reviews, provisioning/deprovisioning, lifecycle management</div>
+  <div class="focus-item">🤖 <strong>Agentic AI & Non-Human Identity</strong> — Agent lifecycle, MCP, token exchange, authorization policy</div>
+  <div class="focus-item">🛡️ <strong>Identity Security</strong> — Identity proofing, credential management, threat detection</div>
+</div>
 
 
 When I'm not thinking about identity, I'm building AI agents that think about identity for me.

--- a/assets/style.scss
+++ b/assets/style.scss
@@ -860,6 +860,27 @@ a.post-card-link {
   }
 }
 
+// ─── ABOUT FOCUS AREAS ───
+
+.focus-areas {
+  margin: 16px 0 24px;
+}
+
+.focus-item {
+  background: $surface;
+  border-left: 3px solid $accent;
+  padding: 12px 16px;
+  margin-bottom: 10px;
+  border-radius: 0 8px 8px 0;
+  font-size: 15px;
+  color: $textSecondary;
+  line-height: 1.6;
+
+  strong {
+    color: $textPrimary;
+  }
+}
+
 // ─── COMING SOON ───
 
 .coming-soon-message {


### PR DESCRIPTION
## Summary
Adds visual separation to the "What I focus on" items on the About page. Each focus area now renders as an indented card with a green left border and dark surface background.

Before: plain emoji-prefixed paragraphs running together
After: distinct cards with bold category names and muted descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)