### PR TITLE
Rename Talks to Spotlight, add Duo blog post

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -32,7 +32,7 @@
               <a href="{{ site.baseurl }}/ideas">Ideas</a>
               <a href="{{ site.baseurl }}/guides">Guides</a>
               <a href="{{ site.baseurl }}/industry">Industry</a>
-              <a href="{{ site.baseurl }}/talks">Talks</a>
+              <a href="{{ site.baseurl }}/spotlight">Spotlight</a>
               <a href="{{ site.baseurl }}/about">About</a>
             </nav>
           </header>

--- a/_pages/talks.html
+++ b/_pages/talks.html
@@ -1,17 +1,21 @@
 ---
 layout: default
-permalink: /talks/
+permalink: /spotlight/
 ---
 
 <div class="page-title">
-  <h1>Talks</h1>
-  <p>Industry talks, analyst briefings, and conference appearances.</p>
+  <h1>Spotlight</h1>
+  <p>Industry talks, blogs, and conference appearances.</p>
 </div>
 
 <div class="section">
+  <div class="section-header">
+    <h2>Talks</h2>
+  </div>
+
   <div class="talk-card">
     <h4>Cisco Presents: IAM Built for the Imposter Era</h4>
-    <div class="talk-venue">Identiverse 2025 - Mandalay Bay, Las Vegas &bull; June 4, 2025</div>
+    <div class="talk-venue">Identiverse 2025 &mdash; Mandalay Bay, Las Vegas &bull; June 4, 2025</div>
     <div class="talk-desc">How a security-first approach to IAM can address key security concerns while reducing complexity and costs. Explores strategies for balancing frictionless access with effective impostor detection, and flexible identity management suited for today's extended workforce.</div>
     <div class="talk-meta">
       <a href="https://identiverse.com/idv25/session/?idvid=2997608">Session details</a>
@@ -22,7 +26,7 @@ permalink: /talks/
   <div class="talk-card">
     <h4>Duo's Big Unveil: Announcing Duo IAM</h4>
     <div class="talk-venue">Duo Security Livestream &bull; May 29, 2025</div>
-    <div class="talk-desc">Joined <a href="https://www.linkedin.com/in/mcaulfie/">Matt Caulfield</a>, VP of Identity at Duo, to announce Duo IAM; Cisco's entry into the IAM and Identity Security market. Live unveil of what attackers will hate and users will love.</div>
+    <div class="talk-desc">Joined <a href="https://www.linkedin.com/in/mcaulfie/">Matt Caulfield</a>, VP of Identity at Duo, to announce Duo IAM &mdash; Cisco's entry into the IAM and Identity Security market. Live unveil of what attackers will hate and users will love.</div>
     <div class="talk-meta">
       <a href="https://www.youtube.com/watch?v=BSVl239nJnc">Watch on YouTube</a>
     </div>
@@ -30,10 +34,25 @@ permalink: /talks/
 
   <div class="talk-card">
     <h4>Innovation in Authentication and More</h4>
-    <div class="talk-venue">Authenticate 2024 Keynote - FIDO Alliance &bull; October 15, 2024</div>
-    <div class="talk-desc">Keynote presentation with <a href="https://www.linkedin.com/in/iammatthewmiller/">Matthew Miller</a> exploring innovation in authentication - passkeys, FIDO standards, and what's next for passwordless.</div>
+    <div class="talk-venue">Authenticate 2024 Keynote &mdash; FIDO Alliance &bull; October 15, 2024</div>
+    <div class="talk-desc">Keynote presentation with <a href="https://www.linkedin.com/in/iammatthewmiller/">Matthew Miller</a> exploring innovation in authentication &mdash; passkeys, FIDO standards, and what's next for passwordless.</div>
     <div class="talk-meta">
       <a href="https://www.youtube.com/watch?v=nwJWE9qxmKw">Watch on YouTube</a>
+    </div>
+  </div>
+</div>
+
+<div class="section">
+  <div class="section-header">
+    <h2>Writing</h2>
+  </div>
+
+  <div class="talk-card">
+    <h4>Turning Microsoft's MFA Requirement for Azure into an Epic Security Win with Duo</h4>
+    <div class="talk-venue">Duo Blog &bull; September 12, 2024</div>
+    <div class="talk-desc">Microsoft's mandatory MFA requirement for Azure began rolling out in October 2024. This post covers how Duo satisfies the mandate through SSO, External Authentication Methods, and ADFS &mdash; and why authentication alone isn't enough. Makes the case for Continuous Identity Security: layering MFA, passwordless, and identity threat detection.</div>
+    <div class="talk-meta">
+      <a href="https://duo.com/blog/turning-microsoft-mfa-requirement-for-azure-into-epic-security-win-with-duo">Read on Duo Blog</a>
     </div>
   </div>
 </div>

--- a/_pages/talks.html
+++ b/_pages/talks.html
@@ -40,6 +40,15 @@ permalink: /spotlight/
       <a href="https://www.youtube.com/watch?v=nwJWE9qxmKw">Watch on YouTube</a>
     </div>
   </div>
+
+  <div class="talk-card">
+    <h4>Give Your Users a Diamond Status Authentication Experience</h4>
+    <div class="talk-venue">Identiverse 2024 &mdash; Las Vegas &bull; May 29, 2024</div>
+    <div class="talk-desc">Using the metaphor of airline Diamond Status to rethink authentication UX. Today's users endure multiple logins across OS, browser, email, and VPN &mdash; the equivalent of standing in every airport line. This talk makes the case for a "Diamond Status" experience: secure passwordless desktop login with trusted sessions persisting across all applications, plus dynamic post-authentication risk assessment that reacts to threats without frustrating users.</div>
+    <div class="talk-meta">
+      <a href="{{ site.baseurl }}/files/identiverse-2024-diamond-status.pptx">Slides (PPTX)</a>
+    </div>
+  </div>
 </div>
 
 <div class="section">


### PR DESCRIPTION
## Summary
- **Renamed** "Talks" → "Spotlight" in nav and page title
- **Updated subtitle**: "Industry talks, blogs, and conference appearances." (removed analyst briefings)
- **Split page** into two sections: **Talks** and **Writing**
- **Added Duo blog**: "Turning Microsoft's MFA Requirement for Azure into an Epic Security Win with Duo" (Sept 12, 2024)
- **Permalink**: `/talks/` → `/spotlight/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)