### PR TITLE
Homepage: feature Duo IAM Unveil, latest 5 cross-section feed

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@ layout: default
 <div class="hero">
   <div class="hero-tagline">Identity. Asserted.</div>
   <h1>Who gets access.<br>What gets access.<br>Under what <span class="accent">constraints.</span></h1>
-  <p>Opinions, analysis, and technical deep-dives on identity infrastructure; from authentication and governance to agentic AI and the future of non-human identity.</p>
+  <p>Opinions, analysis, and technical deep-dives on identity infrastructure &mdash; from authentication and governance to agentic AI and the future of non-human identity.</p>
   <div class="hero-author">
     <div class="hero-author-info">
       <strong>Chris Anderson</strong><br>
@@ -14,28 +14,70 @@ layout: default
   </div>
 </div>
 
-<!-- Featured Post -->
+<!-- Featured -->
 <div class="section">
   <div class="section-header">
     <h2>Featured</h2>
   </div>
-  <a href="{{ site.baseurl }}/Duo-SSO-NinjaOne/" class="post-card post-card-featured post-card-link">
+  <a href="https://www.youtube.com/watch?v=BSVl239nJnc" class="post-card post-card-featured post-card-link">
     <div class="post-card-meta">
-      <span class="post-card-tag">SAML Guide</span>
-      <span class="post-card-date">January 22, 2022</span>
+      <span class="post-card-tag">Spotlight</span>
+      <span class="post-card-date">May 29, 2025</span>
     </div>
-    <h3>Duo SSO + NinjaOne Configuration Guide</h3>
-    <p>How to Configure Duo SSO SAML 2.0 for NinjaOne. Step-by-step integration guide with prerequisites, configuration steps, and testing.</p>
+    <h3>Duo's Big Unveil: Announcing Duo IAM</h3>
+    <p>Joined Matt Caulfield, VP of Identity at Duo, to announce Duo IAM &mdash; Cisco's entry into the IAM and Identity Security market. Live unveil of what attackers will hate and users will love.</p>
   </a>
 </div>
 
-<!-- Latest -->
+<!-- Latest 5 -->
 <div class="section">
   <div class="section-header">
     <h2>Latest</h2>
-    <a href="{{ site.baseurl }}/guides">All guides &rarr;</a>
   </div>
-  <div class="coming-soon-message">
-    <p>More content coming soon. In the meantime, check out the <a href="{{ site.baseurl }}/guides">Guides</a> section for Duo SSO SAML integration walkthroughs.</p>
+  <div class="post-grid">
+    <a href="https://identiverse.com/idv25/session/?idvid=2997608" class="post-card post-card-link">
+      <div class="post-card-meta">
+        <span class="post-card-tag">Spotlight</span>
+        <span class="post-card-date">June 4, 2025</span>
+      </div>
+      <h3>Cisco Presents: IAM Built for the Imposter Era</h3>
+      <p>How a security-first approach to IAM can address key security concerns while reducing complexity and costs. Identiverse 2025, Las Vegas.</p>
+    </a>
+
+    <a href="https://www.youtube.com/watch?v=nwJWE9qxmKw" class="post-card post-card-link">
+      <div class="post-card-meta">
+        <span class="post-card-tag">Spotlight</span>
+        <span class="post-card-date">October 15, 2024</span>
+      </div>
+      <h3>Innovation in Authentication and More</h3>
+      <p>Authenticate 2024 keynote with Matthew Miller exploring passkeys, FIDO standards, and what's next for passwordless.</p>
+    </a>
+
+    <a href="https://duo.com/blog/turning-microsoft-mfa-requirement-for-azure-into-epic-security-win-with-duo" class="post-card post-card-link">
+      <div class="post-card-meta">
+        <span class="post-card-tag">Spotlight</span>
+        <span class="post-card-date">September 12, 2024</span>
+      </div>
+      <h3>Turning Microsoft's MFA Requirement for Azure into an Epic Security Win with Duo</h3>
+      <p>How Duo satisfies Microsoft's mandatory MFA requirement for Azure &mdash; and why authentication alone isn't enough.</p>
+    </a>
+
+    <a href="{{ site.baseurl }}/files/identiverse-2024-diamond-status.pptx" class="post-card post-card-link">
+      <div class="post-card-meta">
+        <span class="post-card-tag">Spotlight</span>
+        <span class="post-card-date">May 29, 2024</span>
+      </div>
+      <h3>Give Your Users a Diamond Status Authentication Experience</h3>
+      <p>Using the metaphor of airline Diamond Status to rethink authentication UX. Identiverse 2024, Las Vegas.</p>
+    </a>
+
+    <a href="{{ site.baseurl }}/Duo-SSO-NinjaOne/" class="post-card post-card-link">
+      <div class="post-card-meta">
+        <span class="post-card-tag">Guide</span>
+        <span class="post-card-date">January 22, 2022</span>
+      </div>
+      <h3>Duo SSO + NinjaOne Configuration Guide</h3>
+      <p>How to Configure Duo SSO SAML 2.0 for NinjaOne. Step-by-step integration guide with prerequisites, configuration steps, and testing.</p>
+    </a>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- **Featured card**: Now shows "Duo's Big Unveil: Announcing Duo IAM" (May 29, 2025) → links to YouTube
- **Latest section**: Replaced "coming soon" with the 5 most recent items across all content types, ordered by real-world publish date:

| # | Item | Type | Date |
|---|------|------|------|
| 1 | Identiverse 2025: IAM Built for the Imposter Era | Spotlight | Jun 4, 2025 |
| 2 | Authenticate 2024: Innovation in Authentication | Spotlight | Oct 15, 2024 |
| 3 | Duo Blog: Azure MFA Requirement | Spotlight | Sep 12, 2024 |
| 4 | Identiverse 2024: Diamond Status | Spotlight | May 29, 2024 |
| 5 | NinjaOne Guide | Guide | Jan 22, 2022 |

Each card is tagged with its content type (Spotlight/Guide) and links to the appropriate destination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)