### PR TITLE
Upgrade Google Analytics from UA to GA4

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -41,7 +41,7 @@ footer-links:
 disqus: chris-anderson-cloud
 
 # Enter your Google Analytics web tracking code (e.g. UA-2110908-2) to activate tracking
-google_analytics: UA-166246781-2
+google_analytics: G-HSS41JXX1N
 
 # Your website URL (e.g. http://amitmerchant1990.github.io or http://www.amitmerchant.com)
 # Used for Sitemap.xml and your RSS feed

--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -1,16 +1,11 @@
 {% if site.google_analytics %}
-	<!-- Google Analytics -->
-	<script>
-		(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-		(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-		m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-		})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-		ga('create', '{{ site.google_analytics }}', 'auto');
-		ga('send', 'pageview', {
-		  'page': '{{ site.baseurl }}{{ page.url }}',
-		  'title': '{{ page.title | replace: "'", "\\'" }}'
-		});
-	</script>
-	<!-- End Google Analytics -->
+<!-- Google Analytics (GA4) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', '{{ site.google_analytics }}');
+</script>
+<!-- End Google Analytics -->
 {% endif %}


### PR DESCRIPTION
## Summary
- Replaced dead Universal Analytics (`UA-166246781-2`) with GA4 (`G-HSS41JXX1N`)
- Updated `_includes/analytics.html` from `analytics.js` to `gtag.js` snippet
- UA stopped processing data in July 2023, so no tracking has been active

## Files changed
- `_config.yml` — measurement ID
- `_includes/analytics.html` — GA4 gtag.js snippet

🤖 Generated with [Claude Code](https://claude.com/claude-code)