### PR TITLE
Remove header tagline, tighten spacing

### DIFF
--- a/assets/style.scss
+++ b/assets/style.scss
@@ -244,35 +244,12 @@ p > img {
 }
 
 .site-info {
-  float: none;
-  clear: left;
-
-  @include mobile {
-    float: none;
-    display: block;
-    margin: 0 auto;
-  }
-}
-
-.site-name {
   display: none;
-}
-
-.site-description {
-  margin-top: 4px;
-  color: $textMuted;
-  font-size: 14px;
-  font-weight: 500;
-  letter-spacing: 0.05em;
-
-  @include mobile {
-    margin: 3px 0;
-  }
 }
 
 nav {
   float: right;
-  margin-top: 16px;
+  margin-top: 12px;
   font-family: $helvetica;
   font-size: 14px;
 


### PR DESCRIPTION
## Summary
- Hide `.site-info` block (contained "Identity. Asserted." tagline below the logo)
- Removes the large vertical gap between the logo and nav links
- Tagline still appears in the homepage hero section and footer

## Test plan
- [ ] Verify logo and nav links are close together in the header
- [ ] Verify "Identity. Asserted." no longer appears between logo and nav
- [ ] Verify tagline still shows in hero section on homepage
- [ ] Verify footer still shows "The Assertion - Identity. Asserted."
- [ ] Check mobile layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)