### PR TITLE
Add mobile hamburger navigation menu

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -27,6 +27,11 @@
               <p class="site-description">{{ site.description }}</p>
             </div>
 
+            <button class="nav-toggle" aria-label="Toggle navigation" onclick="document.querySelector('.masthead').classList.toggle('nav-open')">
+              <span></span>
+              <span></span>
+              <span></span>
+            </button>
             <nav>
               <a href="{{ site.baseurl }}/">Home</a>
               <a href="{{ site.baseurl }}/ideas">Ideas</a>

--- a/assets/style.scss
+++ b/assets/style.scss
@@ -219,6 +219,7 @@ p > img {
 
 .masthead {
   padding: 16px 0;
+  position: relative;
 
   @include mobile {
     text-align: center;
@@ -247,6 +248,46 @@ p > img {
   display: none;
 }
 
+// Hamburger toggle — hidden on desktop
+.nav-toggle {
+  display: none;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 8px;
+  position: absolute;
+  right: 24px;
+  top: 20px;
+  z-index: 10;
+
+  span {
+    display: block;
+    width: 22px;
+    height: 2px;
+    background: $textSecondary;
+    margin: 5px 0;
+    border-radius: 2px;
+    transition: transform 0.3s, opacity 0.3s;
+  }
+
+  @include mobile {
+    display: block;
+  }
+}
+
+// Animate hamburger to X when open
+.nav-open .nav-toggle {
+  span:nth-child(1) {
+    transform: rotate(45deg) translate(5px, 5px);
+  }
+  span:nth-child(2) {
+    opacity: 0;
+  }
+  span:nth-child(3) {
+    transform: rotate(-45deg) translate(5px, -5px);
+  }
+}
+
 nav {
   float: right;
   margin-top: 12px;
@@ -254,10 +295,11 @@ nav {
   font-size: 14px;
 
   @include mobile {
+    display: none;
     float: none;
-    margin-top: 9px;
-    display: block;
-    font-size: 14px;
+    margin-top: 12px;
+    padding: 16px 0 8px;
+    border-top: 1px solid $border;
   }
 
   a {
@@ -274,9 +316,25 @@ nav {
     }
 
     @include mobile {
-      margin: 0 10px;
-      color: $accent;
+      display: block;
+      margin: 0;
+      padding: 10px 0;
+      text-align: center;
+      font-size: 16px;
+      color: $textSecondary;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+
+      &:last-child {
+        border-bottom: none;
+      }
     }
+  }
+}
+
+// Show nav when menu is open on mobile
+.nav-open nav {
+  @include mobile {
+    display: block;
   }
 }
 


### PR DESCRIPTION
## Summary
- Replace horizontal nav links with a hamburger menu on mobile (≤640px)
- Three-line icon toggles to X when open, reveals vertical nav dropdown
- Desktop navigation unchanged — links still float right
- Pure CSS + vanilla JS toggle (no dependencies)

## Test plan
- [ ] Desktop: nav links display horizontally as before
- [ ] Mobile: hamburger icon visible, nav links hidden
- [ ] Mobile: tapping hamburger reveals vertical nav with all 6 links
- [ ] Mobile: tapping X closes the menu
- [ ] Mobile: nav links are tappable and navigate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)