### PR TITLE
Add animated shield logo (rotate + breathe)

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,7 +20,26 @@
       <div class="wrapper-masthead">
         <div class="container">
           <header class="masthead clearfix">
-            <a href="{{ site.baseurl }}/" class="site-avatar"><img src="{{ site.baseurl }}{{ site.avatar }}" alt="{{ site.title }}" /></a>
+            <a href="{{ site.baseurl }}/" class="site-avatar">
+              <svg class="logo-animated" width="400" height="80" viewBox="0 0 400 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <g class="shield-group" transform="translate(20, 10)">
+                  <path class="shield-outline" d="M30 5 L50 10 L55 15 L55 35 L50 45 L30 55 L10 45 L5 35 L5 15 L10 10 Z"
+                        fill="none" stroke="#2dd882" stroke-width="2.5" stroke-linejoin="round"/>
+                  <path class="bracket" d="M20 20 L15 30 L20 40"
+                        stroke="#2dd882" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" opacity="0.4"/>
+                  <path class="bracket" d="M40 20 L45 30 L40 40"
+                        stroke="#2dd882" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" opacity="0.4"/>
+                  <path class="checkmark" d="M22 30 L28 36 L42 22"
+                        stroke="#2dd882" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+                </g>
+                <g class="logo-text" transform="translate(100, 0)">
+                  <text x="0" y="28" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+                        font-size="14" font-weight="500" letter-spacing="2" fill="#e8eaed">THE</text>
+                  <text x="0" y="54" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+                        font-size="28" font-weight="700" letter-spacing="1" fill="#e8eaed">ASSERTION</text>
+                </g>
+              </svg>
+            </a>
 
             <div class="site-info">
               <h1 class="site-name"><a href="{{ site.baseurl }}/">{{ site.name }}</a></h1>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -22,21 +22,25 @@
           <header class="masthead clearfix">
             <a href="{{ site.baseurl }}/" class="site-avatar">
               <svg class="logo-animated" width="400" height="80" viewBox="0 0 400 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <g class="shield-group" transform="translate(20, 10)">
-                  <path class="shield-outline" d="M30 5 L50 10 L55 15 L55 35 L50 45 L30 55 L10 45 L5 35 L5 15 L10 10 Z"
-                        fill="none" stroke="#2dd882" stroke-width="2.5" stroke-linejoin="round"/>
-                  <path class="bracket" d="M20 20 L15 30 L20 40"
-                        stroke="#2dd882" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" opacity="0.4"/>
-                  <path class="bracket" d="M40 20 L45 30 L40 40"
-                        stroke="#2dd882" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" opacity="0.4"/>
-                  <path class="checkmark" d="M22 30 L28 36 L42 22"
-                        stroke="#2dd882" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+                <g transform="translate(20, 10)">
+                  <g class="shield-group">
+                    <path class="shield-outline" d="M30 5 L50 10 L55 15 L55 35 L50 45 L30 55 L10 45 L5 35 L5 15 L10 10 Z"
+                          fill="none" stroke="#2dd882" stroke-width="2.5" stroke-linejoin="round"/>
+                    <path class="bracket" d="M20 20 L15 30 L20 40"
+                          stroke="#2dd882" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" opacity="0.4"/>
+                    <path class="bracket" d="M40 20 L45 30 L40 40"
+                          stroke="#2dd882" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" opacity="0.4"/>
+                    <path class="checkmark" d="M22 30 L28 36 L42 22"
+                          stroke="#2dd882" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+                  </g>
                 </g>
-                <g class="logo-text" transform="translate(100, 0)">
-                  <text x="0" y="28" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-                        font-size="14" font-weight="500" letter-spacing="2" fill="#e8eaed">THE</text>
-                  <text x="0" y="54" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-                        font-size="28" font-weight="700" letter-spacing="1" fill="#e8eaed">ASSERTION</text>
+                <g transform="translate(100, 0)">
+                  <g class="logo-text">
+                    <text x="0" y="28" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+                          font-size="14" font-weight="500" letter-spacing="2" fill="#e8eaed">THE</text>
+                    <text x="0" y="54" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+                          font-size="28" font-weight="700" letter-spacing="1" fill="#e8eaed">ASSERTION</text>
+                  </g>
                 </g>
               </svg>
             </a>

--- a/assets/style.scss
+++ b/assets/style.scss
@@ -231,6 +231,7 @@ p > img {
   width: 350px;
   height: auto;
   margin-right: 15px;
+  perspective: 400px;
 
   @include mobile {
     float: none;
@@ -239,13 +240,67 @@ p > img {
     width: 280px;
   }
 
-  img {
-    border-radius: 0;
+  svg {
+    width: 100%;
+    height: auto;
   }
 }
 
 .site-info {
   display: none;
+}
+
+// ─── LOGO ANIMATION ───
+
+// Phase 1: Rotate Reveal on page load
+@keyframes shieldRotateIn {
+  0% { transform: rotateY(90deg); opacity: 0; }
+  100% { transform: rotateY(0deg); opacity: 1; }
+}
+
+@keyframes checkDrawIn {
+  0%, 65% { stroke-dashoffset: 40; opacity: 0; }
+  100% { stroke-dashoffset: 0; opacity: 1; }
+}
+
+@keyframes textFadeIn {
+  0%, 40% { opacity: 0; transform: translateX(-8px); }
+  100% { opacity: 1; transform: translateX(0); }
+}
+
+// Phase 2: Gentle Breathe (starts after load animation)
+@keyframes breatheScale {
+  0%, 100% { transform: scale(1) rotateY(0deg); }
+  50% { transform: scale(1.04) rotateY(0deg); }
+}
+
+@keyframes breatheBrackets {
+  0%, 100% { opacity: 0.3; }
+  50% { opacity: 0.6; }
+}
+
+.logo-animated {
+  .shield-group {
+    transform-origin: 50px 37px;
+    animation: shieldRotateIn 0.8s cubic-bezier(0.22, 1, 0.36, 1) forwards,
+               breatheScale 4s ease-in-out 2s infinite;
+  }
+
+  .checkmark {
+    stroke-dasharray: 40;
+    stroke-dashoffset: 40;
+    opacity: 0;
+    animation: checkDrawIn 1.4s ease-out forwards;
+  }
+
+  .bracket {
+    animation: breatheBrackets 4s ease-in-out 2s infinite;
+  }
+
+  .logo-text {
+    opacity: 0;
+    animation: textFadeIn 1s ease-out forwards;
+  }
 }
 
 // Hamburger toggle — hidden on desktop

--- a/assets/style.scss
+++ b/assets/style.scss
@@ -281,7 +281,7 @@ p > img {
 
 .logo-animated {
   .shield-group {
-    transform-origin: 50px 37px;
+    transform-origin: 30px 30px;
     animation: shieldRotateIn 0.8s cubic-bezier(0.22, 1, 0.36, 1) forwards,
                breatheScale 4s ease-in-out 2s infinite;
   }


### PR DESCRIPTION
## Summary
- Inline SVG logo in layout (replaces `<img>` tag) to enable CSS animation control
- **Page load**: Shield rotates in (3D Y-axis flip), checkmark draws in, text fades in
- **Idle**: Gentle breathe scale pulse on shield + bracket opacity cycling (starts after load completes)

## Test plan
- [ ] Desktop: shield rotates in on page load, checkmark draws after
- [ ] Desktop: after ~2s, subtle breathe animation begins
- [ ] Mobile: same animations work at smaller size
- [ ] Logo text ("THE ASSERTION") fades in smoothly
- [ ] Navigation still works (logo links to home)
- [ ] No layout shift from inlined SVG vs previous `<img>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)