### PR TITLE
Fix checkmark spacing in shield logo

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -30,7 +30,7 @@
                           stroke="#2dd882" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" opacity="0.4"/>
                     <path class="bracket" d="M40 20 L45 30 L40 40"
                           stroke="#2dd882" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" opacity="0.4"/>
-                    <path class="checkmark" d="M22 30 L28 36 L42 22"
+                    <path class="checkmark" d="M22 30 L28 36 L35 25"
                           stroke="#2dd882" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
                   </g>
                 </g>

--- a/images/logo-horizontal.svg
+++ b/images/logo-horizontal.svg
@@ -23,7 +23,7 @@
           opacity="0.4"/>
 
     <!-- Checkmark (dominant) -->
-    <path d="M22 30 L28 36 L42 22"
+    <path d="M22 30 L28 36 L35 25"
           stroke="#2dd882"
           stroke-width="3.5"
           stroke-linecap="round"


### PR DESCRIPTION
## Summary
- Balance checkmark clearance from both code brackets in the shield logo
- Right tip pulled inward from (42,22) to (35,25) — now ~7px gap on both sides
- Updated both inline SVG in layout and standalone SVG file

## Test plan
- [ ] Checkmark has equal spacing from left and right brackets
- [ ] Animation still draws correctly
- [ ] Logo renders properly on desktop and mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)