### PR TITLE
Add Identiverse 2026 talk to Spotlight

### DIFF
--- a/_pages/talks.html
+++ b/_pages/talks.html
@@ -13,6 +13,16 @@ permalink: /spotlight/
     <h2>Talks</h2>
   </div>
 
+  <div class="talk-card" style="border-color: rgba(45, 216, 130, 0.3); background: linear-gradient(135deg, #1a1f2e 0%, rgba(45, 216, 130, 0.05) 100%);">
+    <div style="display: inline-block; font-size: 11px; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; color: #0f1219; background: #2dd882; padding: 3px 10px; border-radius: 4px; margin-bottom: 12px;">Coming Soon</div>
+    <h4>Not Just Passkeys: Rethinking the Scope of Phishing-Resistant MFA</h4>
+    <div class="talk-venue">Identiverse 2026 &mdash; Mandalay Bay, Las Vegas &bull; June 17, 2026</div>
+    <div class="talk-desc">Phishing-resistant authentication extends beyond login protection. Attackers have shifted focus to enrollment flows, helpdesk tickets, session cookies, and password-dependent fallback mechanisms. This session covers identity verification during enrollment and recovery, proximity-based authentication alternatives, architectures eliminating passwords entirely, session theft mitigation, and integrating phishing-resistant protections into legacy systems.</div>
+    <div class="talk-meta">
+      <a href="https://identiverse.com/idv26/session/?idvid=4056442">Session details</a>
+    </div>
+  </div>
+
   <div class="talk-card">
     <h4>Cisco Presents: IAM Built for the Imposter Era</h4>
     <div class="talk-venue">Identiverse 2025 &mdash; Mandalay Bay, Las Vegas &bull; June 4, 2025</div>


### PR DESCRIPTION
## Summary
- Adds "Not Just Passkeys: Rethinking the Scope of Phishing-Resistant MFA" as a featured coming-soon entry on the Spotlight page
- Talk is June 17, 2026 at Identiverse in Las Vegas
- Uses featured card styling (green border + gradient) with a "Coming Soon" badge

## Test plan
- [ ] Verify Spotlight page renders the new card at the top of the Talks section
- [ ] Verify "Coming Soon" badge displays with green background
- [ ] Verify session details link works: https://identiverse.com/idv26/session/?idvid=4056442

🤖 Generated with [Claude Code](https://claude.com/claude-code)