### PR TITLE
Update homepage Latest with new content

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,24 @@ layout: default
     <h2>Latest</h2>
   </div>
   <div class="post-grid">
+    <a href="https://identiverse.com/idv26/session/?idvid=4056442" class="post-card post-card-link">
+      <div class="post-card-meta">
+        <span class="post-card-tag">Spotlight</span>
+        <span class="post-card-date">June 17, 2026</span>
+      </div>
+      <h3>Not Just Passkeys: Rethinking the Scope of Phishing-Resistant MFA</h3>
+      <p>Phishing-resistant authentication extends beyond login. Covering enrollment, recovery, session theft, and legacy integration. Identiverse 2026, Las Vegas.</p>
+    </a>
+
+    <a href="{{ site.baseurl }}/Duo-SSO-VMware-vCenter/" class="post-card post-card-link">
+      <div class="post-card-meta">
+        <span class="post-card-tag">Guide</span>
+        <span class="post-card-date">April 3, 2026</span>
+      </div>
+      <h3>Duo SSO + VMware vCenter Server Configuration Guide</h3>
+      <p>How to configure Duo SSO (OAuth 2.1 / OIDC) for VMware vCenter Server Identity Federation. Step-by-step with user provisioning and troubleshooting.</p>
+    </a>
+
     <a href="https://identiverse.com/idv25/session/?idvid=2997608" class="post-card post-card-link">
       <div class="post-card-meta">
         <span class="post-card-tag">Spotlight</span>
@@ -60,24 +78,6 @@ layout: default
       </div>
       <h3>Turning Microsoft's MFA Requirement for Azure into an Epic Security Win with Duo</h3>
       <p>How Duo satisfies Microsoft's mandatory MFA requirement for Azure &mdash; and why authentication alone isn't enough.</p>
-    </a>
-
-    <a href="{{ site.baseurl }}/files/identiverse-2024-diamond-status.pptx" class="post-card post-card-link">
-      <div class="post-card-meta">
-        <span class="post-card-tag">Spotlight</span>
-        <span class="post-card-date">May 29, 2024</span>
-      </div>
-      <h3>Give Your Users a Diamond Status Authentication Experience</h3>
-      <p>Using the metaphor of airline Diamond Status to rethink authentication UX. Identiverse 2024, Las Vegas.</p>
-    </a>
-
-    <a href="{{ site.baseurl }}/Duo-SSO-NinjaOne/" class="post-card post-card-link">
-      <div class="post-card-meta">
-        <span class="post-card-tag">Guide</span>
-        <span class="post-card-date">January 22, 2022</span>
-      </div>
-      <h3>Duo SSO + NinjaOne Configuration Guide</h3>
-      <p>How to Configure Duo SSO SAML 2.0 for NinjaOne. Step-by-step integration guide with prerequisites, configuration steps, and testing.</p>
     </a>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Adds Identiverse 2026 talk and Duo SSO + vCenter guide to the top of the Latest feed
- Removes two oldest entries (Diamond Status talk, NinjaOne guide) to keep feed at 5
- Featured section unchanged

## Test plan
- [ ] Verify homepage shows 5 Latest cards in date order (newest first)
- [ ] Verify Identiverse 2026 link and vCenter guide link both work
- [ ] Verify Featured section is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)