### PR TITLE
Fix: Categorize blog post under Dispatches

### DIFF
--- a/_pages/dispatches.html
+++ b/_pages/dispatches.html
@@ -9,7 +9,17 @@ permalink: /dispatches/
 </div>
 
 <div class="section">
-  <div class="coming-soon-message">
-    <p>Coming soon. Dispatches on identity infrastructure, agentic AI, industry moves, and whatever else is worth writing about.</p>
+  <div class="post-grid">
+    {% assign dispatches = site.categories.Dispatches %}
+    {% for post in dispatches %}
+    <a href="{{ site.baseurl }}{{ post.url }}" class="post-card post-card-link">
+      <div class="post-card-meta">
+        <span class="post-card-tag">Dispatches</span>
+        <span class="post-card-date">{{ post.date | date: "%B %-d, %Y" }}</span>
+      </div>
+      <h3>{{ post.title }}</h3>
+      <p>{{ post.excerpt | strip_html | truncatewords: 30 }}</p>
+    </a>
+    {% endfor %}
   </div>
 </div>

--- a/_posts/2026-4-7-Duo-Push-AI-Agent-Permissions.md
+++ b/_posts/2026-4-7-Duo-Push-AI-Agent-Permissions.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: I Replaced My AI Agent's Permission System with Duo Push
-categories: Agentic AI
+categories: Dispatches
 excerpt_separator: <!--more-->
 ---
 


### PR DESCRIPTION
## Summary
- Changed post category from `Agentic AI` to `Dispatches` so it lives under the Dispatches section
- Dispatches page now dynamically lists posts in that category instead of showing "coming soon"

## Test plan
- [ ] Blog post appears at /dispatches/
- [ ] Post card shows correct date and excerpt
- [ ] Future Dispatches posts auto-appear on the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)