### PR TITLE
Fix inline code styling for dark theme

### DIFF
--- a/_sass/_highlights.scss
+++ b/_sass/_highlights.scss
@@ -7,13 +7,16 @@
 }
 
 code {
-  font-family:'Bitstream Vera Sans Mono','Courier', monospace;
-  color: #d8d8d8;
+  font-family: 'JetBrains Mono', 'Fira Code', 'Bitstream Vera Sans Mono', 'Courier', monospace;
+  color: #8bc6a8;
+  font-size: 90%;
 }
 
-.highlighter-rouge { 
-  background-color: #FAFAFA; 
-  color: #FF554A; 
+.highlighter-rouge {
+  background: rgba(26, 31, 46, 0.6);
+  color: #8bc6a8;
+  border-radius: 4px;
+  padding: 2px 5px;
 }
 
 .highlight .c { color: #586E75 } /* Comment */


### PR DESCRIPTION
## Summary
- Replaces red-on-white inline code style with muted green on translucent dark background
- Updates font stack to prefer JetBrains Mono / Fira Code
- Adds border-radius and padding for a cleaner look

**Before:** `#FF554A` on `#FAFAFA` (red on white)
**After:** `#8bc6a8` on `rgba(26, 31, 46, 0.6)` (muted green on subtle dark)

## Test plan
- [ ] Check inline code in blog posts looks clean against dark theme
- [ ] Verify code blocks (fenced) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)