### PR TITLE
Fix inline code style in darcula theme override

### DIFF
--- a/_sass/_darcula.scss
+++ b/_sass/_darcula.scss
@@ -6,14 +6,16 @@
 }
 
 code {
-    font-family:'Bitstream Vera Sans Mono','Courier', monospace;
-    color: #d8d8d8;
+    font-family: 'JetBrains Mono', 'Fira Code', 'Bitstream Vera Sans Mono', 'Courier', monospace;
+    color: #8bc6a8;
+    font-size: 90%;
 }
 
-.highlighter-rouge { 
-    background-color: #FAFAFA; 
-    color: #FF554A; 
-    font-size: 16px;
+.highlighter-rouge {
+    background: rgba(26, 31, 46, 0.6);
+    color: #8bc6a8;
+    border-radius: 4px;
+    padding: 2px 5px;
 }
 
 .highlight .hll { background-color: #f1fa8c }


### PR DESCRIPTION
## Summary
- `_darcula.scss` had a duplicate `.highlighter-rouge` with the old red-on-white style that was overriding the fix in `_highlights.scss`
- Updated to match the same muted green on dark background

🤖 Generated with [Claude Code](https://claude.com/claude-code)