### PR TITLE
Add Cloudflare Web Analytics

### DIFF
--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -9,3 +9,7 @@
 </script>
 <!-- End Google Analytics -->
 {% endif %}
+
+<!-- Cloudflare Web Analytics -->
+<script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "868058d099684190990643707ff085cb"}'></script>
+<!-- End Cloudflare Web Analytics -->


### PR DESCRIPTION
## Summary
- Adds Cloudflare Web Analytics JS snippet to `_includes/analytics.html`
- Loads on every page via the default layout, alongside existing Google Analytics
- Privacy-friendly, cookie-free, zero performance impact (deferred script)

## Test plan
- [ ] Verify site builds and deploys on GitHub Pages
- [ ] Check Cloudflare Web Analytics dashboard for incoming data

🤖 Generated with [Claude Code](https://claude.com/claude-code)