### PR TITLE
Add copyright notice to footer

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -77,6 +77,7 @@
           <footer class="footer">
             <div>The Assertion - Identity. Asserted.</div>
             <div>{{ site.author }} | Principal PM & Identity Evangelist, Cisco Duo</div>
+            <div>&copy; 2026 Chris Anderson</div>
           </footer>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Adds © 2026 Chris Anderson below existing footer text

🤖 Generated with [Claude Code](https://claude.com/claude-code)