### PR TITLE
Add tag filters to Dispatches page

### DIFF
--- a/_pages/dispatches.html
+++ b/_pages/dispatches.html
@@ -8,13 +8,23 @@ permalink: /dispatches/
   <p>Opinions, experiments, and field notes from the identity frontlines.</p>
 </div>
 
+<div class="filter-bar">
+  <button class="filter-btn active" data-filter="all">All</button>
+  <button class="filter-btn" data-filter="AI">AI</button>
+  <button class="filter-btn" data-filter="Claude Code">Claude Code</button>
+  <button class="filter-btn" data-filter="Duo">Duo</button>
+</div>
+
 <div class="section">
   <div class="post-grid">
     {% assign dispatches = site.categories.Dispatches %}
     {% for post in dispatches %}
-    <a href="{{ site.baseurl }}{{ post.url }}" class="post-card post-card-link">
+    <a href="{{ site.baseurl }}{{ post.url }}" class="post-card post-card-link" data-tags="{{ post.tags | join: ',' }}">
       <div class="post-card-meta">
         <span class="post-card-tag">Dispatches</span>
+        {% for tag in post.tags %}
+        <span class="post-card-tag post-card-tag-secondary">{{ tag }}</span>
+        {% endfor %}
         <span class="post-card-date">{{ post.date | date: "%B %-d, %Y" }}</span>
       </div>
       <h3>{{ post.title }}</h3>
@@ -23,3 +33,21 @@ permalink: /dispatches/
     {% endfor %}
   </div>
 </div>
+
+<script>
+document.querySelectorAll('.filter-btn').forEach(function(btn) {
+  btn.addEventListener('click', function() {
+    document.querySelectorAll('.filter-btn').forEach(function(b) { b.classList.remove('active'); });
+    btn.classList.add('active');
+    var filter = btn.getAttribute('data-filter');
+    document.querySelectorAll('.post-card').forEach(function(card) {
+      if (filter === 'all') {
+        card.style.display = '';
+      } else {
+        var tags = (card.getAttribute('data-tags') || '').split(',');
+        card.style.display = tags.indexOf(filter) !== -1 ? '' : 'none';
+      }
+    });
+  });
+});
+</script>

--- a/_posts/2026-4-7-Duo-Push-AI-Agent-Permissions.md
+++ b/_posts/2026-4-7-Duo-Push-AI-Agent-Permissions.md
@@ -2,6 +2,7 @@
 layout: post
 title: I Replaced My AI Agent's Permission System with Duo Push
 categories: Dispatches
+tags: [AI, Claude Code, Duo]
 excerpt_separator: <!--more-->
 ---
 

--- a/assets/style.scss
+++ b/assets/style.scss
@@ -775,6 +775,45 @@ a.post-card-link {
   }
 }
 
+// ─── FILTER BAR ───
+
+.filter-bar {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 24px;
+  flex-wrap: wrap;
+}
+
+.filter-btn {
+  background: $surface;
+  color: $textSecondary;
+  border: 1px solid $border;
+  padding: 6px 16px;
+  border-radius: 20px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-family: $helvetica;
+
+  &:hover {
+    color: $textPrimary;
+    border-color: $accent;
+  }
+
+  &.active {
+    background: $accentDim;
+    color: $accent;
+    border-color: $accent;
+  }
+}
+
+.post-card-tag-secondary {
+  background: $surface;
+  color: $textSecondary;
+  border: 1px solid $border;
+}
+
 // ─── GUIDE LIST ───
 
 .guide-list {


### PR DESCRIPTION
## Summary
- Filter bar at top of Dispatches with All, AI, Claude Code, and Duo buttons
- Tags rendered as secondary badges on post cards
- Client-side JS filtering (no page reload)
- Added tags to the Duo Push blog post: AI, Claude Code, Duo

## Test plan
- [ ] Verify filter buttons toggle correctly
- [ ] Verify "All" shows all posts, specific tags filter as expected
- [ ] Check mobile responsiveness of filter bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)