### PR TITLE
Fix Identiverse 2026 talk post date

### DIFF
--- a/_pages/talks.html
+++ b/_pages/talks.html
@@ -16,8 +16,8 @@ permalink: /spotlight/
   <div class="talk-card" style="border-color: rgba(45, 216, 130, 0.3); background: linear-gradient(135deg, #1a1f2e 0%, rgba(45, 216, 130, 0.05) 100%);">
     <div style="display: inline-block; font-size: 11px; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; color: #0f1219; background: #2dd882; padding: 3px 10px; border-radius: 4px; margin-bottom: 12px;">Coming Soon</div>
     <h4>Not Just Passkeys: Rethinking the Scope of Phishing-Resistant MFA</h4>
-    <div class="talk-venue">Identiverse 2026 &mdash; Mandalay Bay, Las Vegas &bull; June 17, 2026</div>
-    <div class="talk-desc">Phishing-resistant authentication extends beyond login protection. Attackers have shifted focus to enrollment flows, helpdesk tickets, session cookies, and password-dependent fallback mechanisms. This session covers identity verification during enrollment and recovery, proximity-based authentication alternatives, architectures eliminating passwords entirely, session theft mitigation, and integrating phishing-resistant protections into legacy systems.</div>
+    <div class="talk-venue">Identiverse 2026 &mdash; Mandalay Bay, Las Vegas &bull; April 3, 2026</div>
+    <div class="talk-desc">On June 17, 2026 I'll be talking about how phishing-resistant authentication extends beyond login protection. Attackers have shifted focus to enrollment flows, helpdesk tickets, session cookies, and password-dependent fallback mechanisms. This session covers identity verification during enrollment and recovery, proximity-based authentication alternatives, architectures eliminating passwords entirely, session theft mitigation, and integrating phishing-resistant protections into legacy systems.</div>
     <div class="talk-meta">
       <a href="https://identiverse.com/idv26/session/?idvid=4056442">Session details</a>
     </div>

--- a/index.html
+++ b/index.html
@@ -47,10 +47,10 @@ layout: default
     <a href="https://identiverse.com/idv26/session/?idvid=4056442" class="post-card post-card-link">
       <div class="post-card-meta">
         <span class="post-card-tag">Spotlight</span>
-        <span class="post-card-date">June 17, 2026</span>
+        <span class="post-card-date">April 3, 2026</span>
       </div>
       <h3>Not Just Passkeys: Rethinking the Scope of Phishing-Resistant MFA</h3>
-      <p>Phishing-resistant authentication extends beyond login. Covering enrollment, recovery, session theft, and legacy integration. Identiverse 2026, Las Vegas.</p>
+      <p>On June 17, 2026 I'll be talking about how phishing-resistant authentication extends beyond login. Covering enrollment, recovery, session theft, and legacy integration. Identiverse 2026, Las Vegas.</p>
     </a>
 
     <a href="{{ site.baseurl }}/Duo-SSO-VMware-vCenter/" class="post-card post-card-link">


### PR DESCRIPTION
## Summary
- Changed the "Not Just Passkeys" talk card date from June 17, 2026 (event date) to April 3, 2026 (when the card was published)
- Moved the event date into the description: "On June 17, 2026 I'll be talking about how..."
- Updated both Spotlight page and Homepage latest feed

## Test plan
- [ ] Verify Spotlight page shows April 3, 2026 date
- [ ] Verify Homepage card shows April 3, 2026 date
- [ ] Verify description reads naturally with the "On June 17" prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)